### PR TITLE
Add link for discord to navbar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,6 +42,7 @@
           {% if site.categories.learners.size > 0 %}
           {% if page.url == '/learners.html' %}<li class="active">{% else %}<li>{% endif %}<a href="{{ "/learners" | relative_url }}">Learners</a></li>
           {% endif %}
+          <a href="https://discord.gg/vBfGp7S">Discord</a></li>
         </ul>
         <ul class="nav navbar-nav navbar-right">
           <li class="dropdown">


### PR DESCRIPTION
This will add a link to a discord chatroom that we can use for posting announcements and sharing links.